### PR TITLE
Generalizing min and max.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ logLevel := Level.Warn
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.0.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/src/main/scala/net/fosdal/oslo/odatetime/package.scala
+++ b/src/main/scala/net/fosdal/oslo/odatetime/package.scala
@@ -6,11 +6,7 @@ import scala.concurrent.duration._
 
 package object odatetime {
 
-  implicit val ordering = Ordering.by[DateTime, Long](_.getMillis)
-
-  def max(d1: DateTime,d2: DateTime): DateTime = if (d1 >= d2) d1 else d2
-
-  def min(d1: DateTime,d2: DateTime): DateTime = if (d1 <= d2) d1 else d2
+  implicit val ordering: Ordering[DateTime] = Ordering.by(_.getMillis)
 
   implicit class DateTimeOps(val dateTime: DateTime) extends AnyVal with Ordered[DateTime] {
 
@@ -21,10 +17,6 @@ package object odatetime {
     def +(duration: FiniteDuration): DateTime = dateTime.plus(duration.toMillis)
 
     def -(duration: FiniteDuration): DateTime = dateTime.minus(duration.toMillis)
-
-    def min(that: DateTime): DateTime = if (this <= that) this.dateTime else that
-
-    def max(that: DateTime): DateTime = if (this >= that) this.dateTime else that
 
   }
 

--- a/src/main/scala/net/fosdal/oslo/oordering/package.scala
+++ b/src/main/scala/net/fosdal/oslo/oordering/package.scala
@@ -1,6 +1,35 @@
 package net.fosdal.oslo
 
+import scala.math.Ordering.Implicits._
+
 package object oordering {
+
+  /**
+    * A functional form of Ops::max. Useful to avoid ambiguities like this:
+    *
+    * {{{
+    *   import scala.math.Ordering.Implicits._
+    *
+    *   "aaa".max("bbb")
+    *   // Error:(17, 13) type mismatch;
+    *   // found   : String("bbb")
+    *   // required: Ordering[?]
+    *   // "aaaa".max("bbb");
+    *   //            ^
+    * }}}
+    *
+    * which crop up when you're trying to invoke `max` on an object that itself has a `max` function already.
+    *
+    * @see [[scala.math.Ordering.max]]
+    */
+  def max[A: Ordering](x: A, y: A): A = x.max(y)
+
+  /**
+    * Like `max`, but for `min`.
+    *
+    * @see [[net.fosdal.oslo.oordering.max]]
+    */
+  def min[A: Ordering](x: A, y: A): A = x.min(y)
 
   implicit class OrderedOps[O](val o: Ordered[O]) extends AnyVal {
 


### PR DESCRIPTION
The two-argument min/max functions were generalized to anything with an Ordering instance and moved into oordering. The odatetime versions were deleted.

Similarly, the object-oriented min/max extension functions are redundant to what's already provided in the standard library through `scala.math.Ordering.Implicits._`, so the DateTime-specific versions were deleted from odatetime. Unless you just really want to save yourself that import, I guess.

Also added some docs to motivate the functional versions.

---

> The weird behavior of the min/max extension methods with String surprised me. Kind of makes me worried about aggressively using extension methods, since any time the receiver already implements a method with the same ... arity, I guess?, then the extension method will fail to take effect and you'll get whatever that other behavior is instead.

> It also kind of surprised me that `"aaa".max("bbb")` doesn't notice that the types don't line up and start looking for extension methods. I wonder why that is.