### PR TITLE
Hotfix/remove scoverage for now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,6 @@ scalaVersion := "2.11.11"
 
 fork := true
 
-coverageMinimum := 10
-
-coverageFailOnMinimum := true
-
-coverageEnabled := true
-
 crossScalaVersions := Seq("2.12.2", "2.11.11")
 
 publishArtifact in Test := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,6 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 // TODO periodically check for resolved sbt-git issue:
@@ -17,4 +16,3 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25"
 
 // TODO integrate with https://github.com/scoverage/sbt-coveralls
 // addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-

--- a/script/test
+++ b/script/test
@@ -4,4 +4,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-sbt clean test scalastyle coverageReport
+sbt clean test scalastyle


### PR DESCRIPTION
scoverage for some reason is in the runtime dependencies when using in a fat jar.

see: https://github.com/scoverage/sbt-scoverage/issues/228

Am unsure of the cause, so for now I'll be removing it to make the release usable again.

tracking issue: https://github.com/sfosdal/oslo/issues/6
